### PR TITLE
fix: Update readme to use npm instead of yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This is a Next.js app. To get started run the following commands in the root dir
 
 ```bash
 echo "OPENAI_API_KEY=sk-your-key" > .env.local
-yarn
-yarn dev
+npm install
+npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
I tried to install the repo using `yarn`, but it failed because it can't resolve `import '@tldraw/tldraw/tldraw.css'`. I was able to fix this by using `npm` instead like in the original repo. I think this is because there is a `package-lock.json` file in this repo, which implies you should use npm even though the README uses yarn. Either the lock file should be replaced with a yarn.lock or the README should be reverted to npm. I opted for the latter.