### PR TITLE
use stable linkid

### DIFF
--- a/app/lib/makeReal.ts
+++ b/app/lib/makeReal.ts
@@ -2,9 +2,6 @@ import { Editor, createShapeId, getSvgAsImage, uniqueId } from '@tldraw/tldraw'
 import { PreviewShape } from '../PreviewShape/PreviewShape'
 import { getHtmlFromOpenAI } from './getHtmlFromOpenAI'
 import { track } from '@vercel/analytics/react'
-import { kv } from '@vercel/kv'
-import { sql } from '@vercel/postgres'
-import { nanoid } from 'nanoid'
 import { uploadLink } from './uploadLink'
 
 export async function makeReal(editor: Editor, apiKey: string) {
@@ -80,12 +77,14 @@ export async function makeReal(editor: Editor, apiKey: string) {
 			throw Error('Could not generate a design from those wireframes.')
 		}
 
-		await uploadLink(newShapeId, html)
+		const linkId = uniqueId()
+
+		await uploadLink(linkId, html)
 
 		editor.updateShape<PreviewShape>({
 			id: newShapeId,
 			type: 'preview',
-			props: { html, source: dataUrl as string, linkUploadVersion: 1 },
+			props: { html, source: dataUrl as string, linkId, linkUploadVersion: 1 },
 		})
 	} catch (e) {
 		editor.deleteShape(newShapeId)

--- a/app/lib/uploadLink.tsx
+++ b/app/lib/uploadLink.tsx
@@ -4,13 +4,12 @@ import { sql } from '@vercel/postgres'
 import { NextResponse } from 'next/server'
 
 export async function uploadLink(shapeId: string, html: string) {
-	if (typeof shapeId !== 'string' || !shapeId.startsWith('shape:')) {
-		throw new Error('shapeId must be a string starting with shape:')
+	if (typeof shapeId !== 'string') {
+		throw new Error('shapeId must be a string')
 	}
 	if (typeof html !== 'string') {
 		throw new Error('html must be a string')
 	}
 
-	shapeId = shapeId.replace(/^shape:/, '')
 	await sql`INSERT INTO links (shape_id, html) VALUES (${shapeId}, ${html})`
 }


### PR DESCRIPTION
We use the shape's id to pull the corresponding link. Duplicating a shape breaks this. This PR adds a stable reference to the linked project. This works! But it's maybe not ideal.

Alternatively, duplicating a shape could re-upload a new file. If we ever allowed users to edit a preview's html then there's a chance of one project changing the link / source for another.