### PR TITLE
implement screenshot with prompt

### DIFF
--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -92,7 +92,7 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 			//listen for screenshot messages
 			if (typeof window !== 'undefined') {
 				const handleEvent = (event: { data: any }) => {
-					if (event.data.shapeid) {
+					if (event.data.shapeid === shape.id) {
 						this.editor.updateShape({
 							props: { ...shape.props, screenshot: event.data.screenshot },
 							id: shape.id,

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -14,7 +14,7 @@ Use your best judgement to determine whether what you see should be part of the 
 Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
 
 The user may also provide you with the html of a previous design that they want you to iterate from.
-In the wireframe, the previous design's html will appear as a white rectangle.
+In the wireframe, the previous design will appear with some notes.
 Use their notes, together with the previous design, to inform your next result.
 
 Sometimes it's hard for you to read the writing in the wireframes.


### PR DESCRIPTION
This PR changes the preview shape so that it also stores a screenshot of the shape to pass along with prompts. It improves the accuracy of the model when implementing changes the user has requested.

Before and after:
![image](https://github.com/tldraw/make-real/assets/98838967/aad057ab-4320-4f55-99e2-7ee16eaeb5ad)
![image](https://github.com/tldraw/make-real/assets/98838967/447d9a34-4f44-4906-ae39-ba7f22c2032b)

The screenshot is generated by injecting a script that loads html2canvas and uses the postmessage api to send a dataurl of the image up to the parent.

Thanks to @SomeHats and @MitjaBezensek for their help!