### PR TITLE
Screenshots with prompt

### DIFF
--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -191,6 +191,9 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 		// while screenshot is the same as the old one, keep waiting for a new one
 		return new Promise((resolve, _) => {
+			const timeOut = setTimeout(() => {
+				resolve(g)
+			}, 2000)
 			if (typeof window !== 'undefined') {
 				const windowListener = (event: MessageEvent) => {
 					if (event.data.screenshot && event.data?.shapeid === shape.id) {
@@ -200,6 +203,7 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 						image.setAttribute('height', shape.props.h.toString())
 						g.appendChild(image)
 						window.removeEventListener('message', windowListener)
+						clearTimeout(timeOut)
 						resolve(g)
 					}
 				}
@@ -217,6 +221,7 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 					console.log('first level iframe not found or not accessible')
 				}
 			} else {
+				clearTimeout(timeOut)
 				resolve(g)
 			}
 		})

--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -23,7 +23,6 @@ export type PreviewShape = TLBaseShape<
 	{
 		html: string
 		source: string
-		screenshot: string
 		w: number
 		h: number
 		linkUploadVersion?: number
@@ -38,7 +37,6 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 		return {
 			html: '',
 			source: '',
-			screenshot: '',
 			w: (960 * 2) / 3,
 			h: (540 * 2) / 3,
 		}

--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -88,31 +88,6 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 			}
 		}, [shape.id, html, linkUploadVersion, uploadedShapeId])
 
-		useEffect(() => {
-			//listen for screenshot messages
-			if (typeof window !== 'undefined') {
-				const windowListener = (event: MessageEvent) => {
-					if (event.data.screenshot && event.data?.shapeid === shape.id) {
-						this.editor.updateShape({
-							props: { ...shape.props, screenshot: event.data.screenshot },
-							id: shape.id,
-							type: 'preview',
-						})
-						;(window as any).screenshot = {
-							shapeid: event.data.shapeid,
-							screenshot: event.data.screenshot,
-						}
-						console.log('useEffect', (window as any).screenshot.screenshot)
-					}
-				}
-				window.addEventListener('message', windowListener)
-
-				return () => {
-					window.removeEventListener('message', windowListener)
-				}
-			}
-		}, [shape.id, shape.props])
-
 		const isLoading = linkUploadVersion === undefined || uploadedShapeId !== shape.id
 
 		const uploadUrl = [PROTOCOL, LINK_HOST, '/', shape.id.replace(/^shape:/, '')].join('')
@@ -212,37 +187,39 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 		)
 	}
 
-	override toSvg(shape: PreviewShape, ctx: SvgExportContext): SVGElement | Promise<SVGElement> {
-		//request new screenshot
-		const firstLevelIframe = document.getElementById(`iframe-1-${shape.id}`) as HTMLIFrameElement
-		if (firstLevelIframe) {
-			firstLevelIframe.contentWindow.postMessage(
-				{ action: 'take-screenshot', shapeid: shape.id },
-				'*'
-			)
-		} else {
-			console.log('first level iframe not found or not accessible')
-		}
+	override toSvg(shape: PreviewShape, _ctx: SvgExportContext): SVGElement | Promise<SVGElement> {
 		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
-
-		const image = document.createElementNS('http://www.w3.org/2000/svg', 'image')
-
 		// while screenshot is the same as the old one, keep waiting for a new one
-		console.log((window as any).screenshot.screenshot)
-		setTimeout(() => {
-			console.log('settiimeout')
-			image.setAttributeNS(
-				'http://www.w3.org/1999/xlink',
-				'href',
-				(window as any).screenshot.screenshot
-			)
-			console.log((window as any).screenshot.screenshot)
-		}, 1000)
-		image.setAttribute('width', shape.props.w.toString())
-		image.setAttribute('height', shape.props.h.toString())
-		g.appendChild(image)
-
-		return g
+		return new Promise((resolve, _) => {
+			if (typeof window !== 'undefined') {
+				const windowListener = (event: MessageEvent) => {
+					if (event.data.screenshot && event.data?.shapeid === shape.id) {
+						const image = document.createElementNS('http://www.w3.org/2000/svg', 'image')
+						image.setAttributeNS('http://www.w3.org/1999/xlink', 'href', event.data.screenshot)
+						image.setAttribute('width', shape.props.w.toString())
+						image.setAttribute('height', shape.props.h.toString())
+						g.appendChild(image)
+						window.removeEventListener('message', windowListener)
+						resolve(g)
+					}
+				}
+				window.addEventListener('message', windowListener)
+				//request new screenshot
+				const firstLevelIframe = document.getElementById(
+					`iframe-1-${shape.id}`
+				) as HTMLIFrameElement
+				if (firstLevelIframe) {
+					firstLevelIframe.contentWindow.postMessage(
+						{ action: 'take-screenshot', shapeid: shape.id },
+						'*'
+					)
+				} else {
+					console.log('first level iframe not found or not accessible')
+				}
+			} else {
+				resolve(g)
+			}
+		})
 	}
 
 	indicator(shape: PreviewShape) {

--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -27,6 +27,7 @@ export type PreviewShape = TLBaseShape<
 		h: number
 		linkUploadVersion?: number
 		uploadedShapeId?: string
+		dateCreated?: number
 	}
 >
 
@@ -39,6 +40,7 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 			source: '',
 			w: (960 * 2) / 3,
 			h: (540 * 2) / 3,
+			dateCreated: Date.now(),
 		}
 	}
 

--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -92,7 +92,7 @@ export class PreviewShapeUtil extends BaseBoxShapeUtil<PreviewShape> {
 			//listen for screenshot messages
 			if (typeof window !== 'undefined') {
 				const handleEvent = (event: { data: any }) => {
-					if (event.data.shapeid) {
+					if (event.data.shapeid === shape.id) {
 						this.editor.updateShape({
 							props: { ...shape.props, screenshot: event.data.screenshot },
 							id: shape.id,

--- a/app/components/ExportButton.tsx
+++ b/app/components/ExportButton.tsx
@@ -3,7 +3,6 @@ import { useMakeReal } from '../hooks/useMakeReal'
 export function ExportButton() {
 	const makeReal = useMakeReal()
 
-	// A tailwind styled button that is pinned to the bottom right of the screen
 	return (
 		<button
 			onClick={makeReal}

--- a/app/components/LinkComponent.tsx
+++ b/app/components/LinkComponent.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useEffect } from 'react'
+
+export function LinkComponent(props) {
+	useEffect(() => {
+		//listen for screenshot messages
+		if (typeof window !== 'undefined') {
+			const windowListener = (event: MessageEvent) => {
+				if (event.data.action === 'take-screenshot') {
+					const iframe2 = document.getElementById(
+						`iframe-2-shape:${props.linkId}`
+					) as HTMLIFrameElement
+					iframe2.contentWindow.postMessage(
+						{ action: 'take-screenshot', shapeid: `shape:${props.linkId}` },
+						'*'
+					)
+				}
+			}
+			window.addEventListener('message', windowListener)
+
+			return () => {
+				window.removeEventListener('message', windowListener)
+			}
+		}
+	}, [])
+
+	return (
+		<iframe
+			id={`iframe-2-shape:${props.linkId}`}
+			srcDoc={props.html}
+			draggable={false}
+			style={{
+				position: 'fixed',
+				inset: 0,
+				width: '100%',
+				height: '100%',
+				border: 'none',
+			}}
+		/>
+	)
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,7 +18,7 @@
 
 .your-own-api-key {
 	position: absolute;
-	bottom: 72px;
+	bottom: 64px;
 	right: 0px;
 	width: 100%;
 	display: flex;
@@ -35,13 +35,14 @@
 	font-size: 12px;
 	font-family: Inter, sans-serif;
 	flex-direction: row;
-	max-width: 300px;
+	max-width: 308px;
 	width: 100%;
 	gap: 4px;
 	background-color: var(--color-low);
 	border-radius: 8px;
 	padding: 6px;
 	pointer-events: all;
+	border: 4px solid var(--color-background);
 }
 
 .your-own-api-key__mobile {

--- a/app/lib/getHtmlFromOpenAI.ts
+++ b/app/lib/getHtmlFromOpenAI.ts
@@ -50,7 +50,7 @@ export async function getHtmlFromOpenAI({
 					},
 					{
 						type: 'text',
-						text: 'Oh, it looks like there was not any text in this design!',
+						text: text ? text : 'Oh, it looks like there was not any text in this design!',
 					},
 				],
 			},

--- a/app/lib/getHtmlFromOpenAI.ts
+++ b/app/lib/getHtmlFromOpenAI.ts
@@ -1,3 +1,4 @@
+import { PreviewShape } from '../PreviewShape/PreviewShape'
 import {
 	OPENAI_USER_PROMPT,
 	OPENAI_USER_PROMPT_WITH_PREVIOUS_DESIGN,
@@ -6,61 +7,98 @@ import {
 
 export async function getHtmlFromOpenAI({
 	image,
-	html,
 	apiKey,
 	text,
 	theme = 'light',
-	includesPreviousDesign,
+	previousPreviews,
 }: {
 	image: string
-	html: string
 	apiKey: string
 	text: string
 	theme?: string
-	includesPreviousDesign?: boolean
+	previousPreviews?: PreviewShape[]
 }) {
+	if (!apiKey) throw Error('You need to provide an API key (sorry)')
+
+	const messages: GPT4VCompletionRequest['messages'] = [
+		{
+			role: 'system',
+			content: OPEN_AI_SYSTEM_PROMPT,
+		},
+		{
+			role: 'user',
+			content: [],
+		},
+	]
+
+	const userContent = messages[1].content as Exclude<MessageContent, string>
+
+	// Add the image
+	userContent.push(
+		{
+			type: 'text',
+			text:
+				previousPreviews.length > 0 ? OPENAI_USER_PROMPT_WITH_PREVIOUS_DESIGN : OPENAI_USER_PROMPT,
+		},
+		{
+			type: 'image_url',
+			image_url: {
+				url: image,
+				detail: 'high',
+			},
+		}
+	)
+
+	// Add the strings of text
+	if (text) {
+		userContent.push({
+			type: 'text',
+			text: `Here's a list of text that we found in the design:\n${text}`,
+		})
+	} else {
+		userContent.push({
+			type: 'text',
+			text: `There wasn't any text in this design. You'll have to work from just the images.`,
+		})
+	}
+
+	// Add the previous previews as HTML
+	for (let i = 0; i < previousPreviews.length; i++) {
+		const preview = previousPreviews[i]
+		userContent.push(
+			{
+				type: 'text',
+				text: `The designs also included this previous result. Here's the image that led to this result (the result's source image).`,
+			},
+			{
+				type: 'image_url',
+				image_url: {
+					url: preview.props.source,
+					detail: 'high',
+				},
+			},
+			{
+				type: 'text',
+				text: `...and here's the HTML you came up with for it: ${preview.props.html}`,
+			}
+		)
+	}
+
+	// Prompt the theme
+	userContent.push({
+		type: 'text',
+		text: `Please make your result use the ${theme} theme.`,
+	})
+
 	const body: GPT4VCompletionRequest = {
 		model: 'gpt-4-vision-preview',
 		max_tokens: 4096,
 		temperature: 0,
-		messages: [
-			{
-				role: 'system',
-				content: OPEN_AI_SYSTEM_PROMPT,
-			},
-			{
-				role: 'user',
-				content: [
-					{
-						type: 'image_url',
-						image_url: {
-							url: image,
-							detail: 'high',
-						},
-					},
-					{
-						type: 'text',
-						text: `${
-							includesPreviousDesign ? OPENAI_USER_PROMPT_WITH_PREVIOUS_DESIGN : OPENAI_USER_PROMPT
-						} Oh, and could you make it for the ${theme} theme?`,
-					},
-					{
-						type: 'text',
-						text: html,
-					},
-					{
-						type: 'text',
-						text: text ? text : 'Oh, it looks like there was not any text in this design!',
-					},
-				],
-			},
-		],
+		messages,
 	}
 
 	let json = null
-	if (!apiKey) {
-		throw Error('You need to provide an API key (sorry)')
-	}
+
 	try {
 		const resp = await fetch('https://api.openai.com/v1/chat/completions', {
 			method: 'POST',

--- a/app/lib/getHtmlFromOpenAI.ts
+++ b/app/lib/getHtmlFromOpenAI.ts
@@ -68,7 +68,7 @@ export async function getHtmlFromOpenAI({
 		userContent.push(
 			{
 				type: 'text',
-				text: `The designs also included this previous result. Here's the image that led to this result (the result's source image).`,
+				text: `The designs also included one of your previous result. Here's the image that you used as its source:`,
 			},
 			{
 				type: 'image_url',
@@ -79,7 +79,7 @@ export async function getHtmlFromOpenAI({
 			},
 			{
 				type: 'text',
-				text: `...and here's the HTML you came up with for it: ${preview.props.html}`,
+				text: `And here's the HTML you came up with for it: ${preview.props.html}`,
 			}
 		)
 	}

--- a/app/lib/makeReal.ts
+++ b/app/lib/makeReal.ts
@@ -43,6 +43,8 @@ export async function makeReal(editor: Editor, apiKey: string) {
 
 	const dataUrl = await blobToBase64(blob!)
 
+	console.log({ dataUrl })
+
 	editor.createShape<PreviewShape>({
 		id: newShapeId,
 		type: 'preview',

--- a/app/lib/makeReal.ts
+++ b/app/lib/makeReal.ts
@@ -43,8 +43,6 @@ export async function makeReal(editor: Editor, apiKey: string) {
 
 	const dataUrl = await blobToBase64(blob!)
 
-	console.log({ dataUrl })
-
 	editor.createShape<PreviewShape>({
 		id: newShapeId,
 		type: 'preview',

--- a/app/lib/makeReal.ts
+++ b/app/lib/makeReal.ts
@@ -35,7 +35,8 @@ export async function makeReal(editor: Editor, apiKey: string) {
 
 	const dataUrl = await blobToBase64(blob!)
 
-	downloadDataURLAsFile(dataUrl, 'tldraw.png')
+	//// For testing, let's see the image
+	// downloadDataURLAsFile(dataUrl, 'tldraw.png')
 
 	editor.createShape<PreviewShape>({
 		id: newShapeId,

--- a/app/makereal.tldraw.link/[linkId]/page.tsx
+++ b/app/makereal.tldraw.link/[linkId]/page.tsx
@@ -23,7 +23,7 @@ export default async function LinkPage({
     // send the screenshot to the parent window
   window.addEventListener('message', function(event) {
     if (event.data.action === 'take-screenshot' && event.data.shapeid === "shape:${linkId}") {
-      html2canvas(document.body, {useCors : true}).then(function(canvas) {
+      html2canvas(document.body, {useCors : true, foreignObjectRendering: true, allowTaint: true }).then(function(canvas) {
         const data = canvas.toDataURL('image/png');
         window.parent.parent.postMessage({screenshot: data, shapeid: "shape:${linkId}"}, "*");
       });

--- a/app/makereal.tldraw.link/[linkId]/page.tsx
+++ b/app/makereal.tldraw.link/[linkId]/page.tsx
@@ -25,7 +25,6 @@ export default async function LinkPage({
     if (event.data.action === 'take-screenshot' && event.data.shapeid === "shape:${linkId}") {
       html2canvas(document.body, {useCors : true}).then(function(canvas) {
         const data = canvas.toDataURL('image/png');
-		console.log('html2canvas', data)
         window.parent.parent.postMessage({screenshot: data, shapeid: "shape:${linkId}"}, "*");
       });
     }

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -14,7 +14,7 @@ Use your best judgement to determine whether what you see should be part of the 
 Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
 
 The user may also provide you with the html of a previous design that they want you to iterate from.
-In the wireframe, the previous design's html will appear as a white rectangle.
+In the wireframe, the previous design will appear with some notes.
 Use their notes, together with the previous design, to inform your next result.
 
 Sometimes it's hard for you to read the writing in the wireframes.

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -1,32 +1,37 @@
-export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes.
-Your job is to accept low-fidelity wireframes, then create a working prototype using HTML, CSS, and JavaScript, and finally send back the results.
-The results should be a single HTML file.
-Use tailwind to style the website.
-Put any additional CSS styles in a style tag and any JavaScript in a script tag.
-Use unpkg or skypack to import any required dependencies.
-Use Google fonts to pull in any open source fonts you require.
-If you have any images, load them from Unsplash or use solid colored rectangles.
+export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes. Your job is to accept low-fidelity designs and turn them into interactive and responsive working prototypes.
 
-The wireframes may include flow charts, diagrams, labels, arrows, sticky notes, and other features that should inform your work.
-If there are screenshots or images, use them to inform the colors, fonts, and layout of your website.
-Use your best judgement to determine whether what you see should be part of the user interface, or else is just an annotation.
+When sent new designs, you should reply with your best attempt at a high fidelity working prototype as a single HTML file.
+
+Use tailwind CSS for styling. If you must use other CSS, place it in a style tag.
+
+Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles. 
 
 Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
 
-The user may also provide you with the html of a previous design that they want you to iterate from.
-In the wireframe, the previous design will appear with some notes.
-Use their notes, together with the previous design, to inform your next result.
+Your prototype should look much more complete and advanced than the wireframes provided. Try your best to figure out what the designer wants and make it happen.
 
-Sometimes it's hard for you to read the writing in the wireframes.
-For this reason, all text from the wireframes will be provided to you as a list of strings, separated by newlines.
-Use the provided list of text from the wireframes as a reference if any text is hard to read.
-
-You love your designers and want them to be happy. Incorporating their feedback and notes and producing working websites makes them happy.
-
-When sent new wireframes, respond ONLY with the contents of the html file.`
+Remember: you love your designers and want them to be happy. Intuiting their intention and incorporating their feedback and notes and producing working websites makes them happy. You've got this!`
 
 export const OPENAI_USER_PROMPT =
-	'Here are the latest wireframes. Could you make a new website based on these wireframes and notes and send back just the html file?'
+	'Here are the latest wireframes. Return a single HMTL file based on these wireframes and notes. Send back just the HTML file contents.'
 
 export const OPENAI_USER_PROMPT_WITH_PREVIOUS_DESIGN =
-	'Here are the latest wireframes including some notes on your previous work. Could you make a new website based on these wireframes and notes and send back just the html file?'
+	'Here are the latest wireframes. There are also some previous outputs here. Could you make a new website based on these wireframes and notes and send back just the html file?'
+
+// # Working from wireframes
+
+// The wireframes may include flow charts, diagrams, labels, arrows, sticky notes, and other features that should inform your work. Use your best judgement to determine what is an annotation and what should be included in the final result.
+// Treat anything in the color red as an annotation rather than part of the design. Do NOT include any red elements or any other annotations in your final result.
+
+// ## Filling in the blanks
+
+// ## Text
+
+// For your reference, all text from the wireframes will be provided to you as a list of strings, separated by newlines.
+// Use the provided list of text from the wireframes as a reference if any text is hard to read.
+
+// ## Previous results
+
+// The user may also provide you with wireframes that include one of your previous results. In the wireframe, the previous design will appear with some notes and annotations. Use this feedback inform your next result.
+
+// # Final notes

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -4,11 +4,11 @@ When sent new designs, you should reply with your best attempt at a high fidelit
 
 Use tailwind CSS for styling. If you must use other CSS, place it in a style tag.
 
-Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles. 
+Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles as placeholders. 
 
 Your prototype should look and feel much more complete and advanced than the wireframes provided. Flesh it out, make it real! Try your best to figure out what the designer wants and make it happen. If there are any questions or underspecified features, use what you know about applications, user experience, and website design patterns to "fill in the blanks". If you're unsure of how the designs should work, take a guess—it's better for you to get it wrong than to leave things incomplete. 
 
-Remember: you love your designers and want them to be happy. The more complete and impressive your prototype, the happier they are. Good luck, you've got this!`
+Remember: you love your designers and want them to be happy. The more complete and impressive your prototype, the happier they will be. Good luck, you've got this!`
 
 export const OPENAI_USER_PROMPT =
 	'Here are the latest wireframes. Return a single HMTL file based on these wireframes and notes. Send back just the HTML file contents.'
@@ -31,5 +31,3 @@ export const OPENAI_USER_PROMPT_WITH_PREVIOUS_DESIGN =
 // ## Previous results
 
 // The user may also provide you with wireframes that include one of your previous results. In the wireframe, the previous design will appear with some notes and annotations. Use this feedback inform your next result.
-
-// # Final notes

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -1,14 +1,29 @@
-export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes. Your job is to accept low-fidelity designs and turn them into interactive and responsive working prototypes. When sent new designs, you should reply with your best attempt at a high fidelity working prototype as a single HTML file.
+export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes.
+Your job is to accept low-fidelity wireframes, then create a working prototype using HTML, CSS, and JavaScript, and finally send back the results.
+The results should be a single HTML file.
+Use tailwind to style the website.
+Put any additional CSS styles in a style tag and any JavaScript in a script tag.
+Use unpkg or skypack to import any required dependencies.
+Use Google fonts to pull in any open source fonts you require.
+If you have any images, load them from Unsplash or use solid colored rectangles.
 
-Use tailwind CSS for styling. If you must use other CSS, place it in a style tag.
+The wireframes may include flow charts, diagrams, labels, arrows, sticky notes, and other features that should inform your work.
+If there are screenshots or images, use them to inform the colors, fonts, and layout of your website.
+Use your best judgement to determine whether what you see should be part of the user interface, or else is just an annotation.
 
-Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles as placeholders. 
+Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
 
-The designs may include flow charts, diagrams, labels, arrows, sticky notes, screenshots of other applications, or even previous designs. Treat all of these as references for your prototype. Use your best judgement to determine what is an annotation and what should be included in the final result. Treat anything in the color red as an annotation rather than part of the design. Do NOT include any red elements or any other annotations in your final result.
+The user may also provide you with the html of a previous design that they want you to iterate from.
+In the wireframe, the previous design's html will appear as a white rectangle.
+Use their notes, together with the previous design, to inform your next result.
 
-Your prototype should look and feel much more complete and advanced than the wireframes provided. Flesh it out, make it real! Try your best to figure out what the designer wants and make it happen. If there are any questions or underspecified features, use what you know about applications, user experience, and website design patterns to "fill in the blanks". If you're unsure of how the designs should work, take a guess—it's better for you to get it wrong than to leave things incomplete. 
+Sometimes it's hard for you to read the writing in the wireframes.
+For this reason, all text from the wireframes will be provided to you as a list of strings, separated by newlines.
+Use the provided list of text from the wireframes as a reference if any text is hard to read.
 
-Remember: you love your designers and want them to be happy. The more complete and impressive your prototype, the happier they will be. Good luck, you've got this!`
+You love your designers and want them to be happy. Incorporating their feedback and notes and producing working websites makes them happy.
+
+When sent new wireframes, respond ONLY with the contents of the html file.`
 
 export const OPENAI_USER_PROMPT =
 	'Here are the latest wireframes. Return a single HMTL file based on these wireframes and notes. Send back just the HTML file contents.'

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -1,29 +1,14 @@
-export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes.
-Your job is to accept low-fidelity wireframes, then create a working prototype using HTML, CSS, and JavaScript, and finally send back the results.
-The results should be a single HTML file.
-Use tailwind to style the website.
-Put any additional CSS styles in a style tag and any JavaScript in a script tag.
-Use unpkg or skypack to import any required dependencies.
-Use Google fonts to pull in any open source fonts you require.
-If you have any images, load them from Unsplash or use solid colored rectangles.
+export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes. Your job is to accept low-fidelity designs and turn them into interactive and responsive working prototypes. When sent new designs, you should reply with your best attempt at a high fidelity working prototype as a single HTML file.
 
-The wireframes may include flow charts, diagrams, labels, arrows, sticky notes, and other features that should inform your work.
-If there are screenshots or images, use them to inform the colors, fonts, and layout of your website.
-Use your best judgement to determine whether what you see should be part of the user interface, or else is just an annotation.
+Use tailwind CSS for styling. If you must use other CSS, place it in a style tag.
 
-Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
+Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles as placeholders. 
 
-The user may also provide you with the html of a previous design that they want you to iterate from.
-In the wireframe, the previous design's html will appear as a white rectangle.
-Use their notes, together with the previous design, to inform your next result.
+The designs may include flow charts, diagrams, labels, arrows, sticky notes, screenshots of other applications, or even previous designs. Treat all of these as references for your prototype. Use your best judgement to determine what is an annotation and what should be included in the final result. Treat anything in the color red as an annotation rather than part of the design. Do NOT include any red elements or any other annotations in your final result.
 
-Sometimes it's hard for you to read the writing in the wireframes.
-For this reason, all text from the wireframes will be provided to you as a list of strings, separated by newlines.
-Use the provided list of text from the wireframes as a reference if any text is hard to read.
+Your prototype should look and feel much more complete and advanced than the wireframes provided. Flesh it out, make it real! Try your best to figure out what the designer wants and make it happen. If there are any questions or underspecified features, use what you know about applications, user experience, and website design patterns to "fill in the blanks". If you're unsure of how the designs should work, take a guess—it's better for you to get it wrong than to leave things incomplete. 
 
-You love your designers and want them to be happy. Incorporating their feedback and notes and producing working websites makes them happy.
-
-When sent new wireframes, respond ONLY with the contents of the html file.`
+Remember: you love your designers and want them to be happy. The more complete and impressive your prototype, the happier they will be. Good luck, you've got this!`
 
 export const OPENAI_USER_PROMPT =
 	'Here are the latest wireframes. Return a single HMTL file based on these wireframes and notes. Send back just the HTML file contents.'

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -6,11 +6,9 @@ Use tailwind CSS for styling. If you must use other CSS, place it in a style tag
 
 Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles. 
 
-Use what you know about applications and user experience to fill in any implicit business logic in the wireframes. Flesh it out, make it real!
+Your prototype should look and feel much more complete and advanced than the wireframes provided. Flesh it out, make it real! Try your best to figure out what the designer wants and make it happen. If there are any questions or underspecified features, use what you know about applications, user experience, and website design patterns to "fill in the blanks". If you're unsure of how the designs should work, take a guess—it's better for you to get it wrong than to leave things incomplete. 
 
-Your prototype should look much more complete and advanced than the wireframes provided. Try your best to figure out what the designer wants and make it happen.
-
-Remember: you love your designers and want them to be happy. Intuiting their intention and incorporating their feedback and notes and producing working websites makes them happy. You've got this!`
+Remember: you love your designers and want them to be happy. The more complete and impressive your prototype, the happier they are. Good luck, you've got this!`
 
 export const OPENAI_USER_PROMPT =
 	'Here are the latest wireframes. Return a single HMTL file based on these wireframes and notes. Send back just the HTML file contents.'

--- a/app/prompt.ts
+++ b/app/prompt.ts
@@ -1,10 +1,10 @@
-export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes. Your job is to accept low-fidelity designs and turn them into interactive and responsive working prototypes.
-
-When sent new designs, you should reply with your best attempt at a high fidelity working prototype as a single HTML file.
+export const OPEN_AI_SYSTEM_PROMPT = `You are an expert web developer who specializes in building working website prototypes from low-fidelity wireframes. Your job is to accept low-fidelity designs and turn them into interactive and responsive working prototypes. When sent new designs, you should reply with your best attempt at a high fidelity working prototype as a single HTML file.
 
 Use tailwind CSS for styling. If you must use other CSS, place it in a style tag.
 
 Put any JavaScript in a script tag. Use unpkg or skypack to import any required JavaScript dependencies. Use Google fonts to pull in any open source fonts you require. If you have any images, load them from Unsplash or use solid colored rectangles as placeholders. 
+
+The designs may include flow charts, diagrams, labels, arrows, sticky notes, screenshots of other applications, or even previous designs. Treat all of these as references for your prototype. Use your best judgement to determine what is an annotation and what should be included in the final result. Treat anything in the color red as an annotation rather than part of the design. Do NOT include any red elements or any other annotations in your final result.
 
 Your prototype should look and feel much more complete and advanced than the wireframes provided. Flesh it out, make it real! Try your best to figure out what the designer wants and make it happen. If there are any questions or underspecified features, use what you know about applications, user experience, and website design patterns to "fill in the blanks". If you're unsure of how the designs should work, take a guess—it's better for you to get it wrong than to leave things incomplete. 
 


### PR DESCRIPTION
This PR changes the preview shape so that it also stores a screenshot of the shape to pass along with prompts. It improves the accuracy of the model when implementing changes the user has requested.

Before and after:
![image](https://github.com/tldraw/make-real/assets/98838967/aad057ab-4320-4f55-99e2-7ee16eaeb5ad)
![image](https://github.com/tldraw/make-real/assets/98838967/447d9a34-4f44-4906-ae39-ba7f22c2032b)

The screenshot is generated by injecting a script that loads html2canvas and uses the postmessage api to send a dataurl of the image up to the parent.

Thanks to @SomeHats for advice and @MitjaBezensek for getting it over the finish line.