### PR TITLE
Add "Open in Replit" option

### DIFF
--- a/app/components/Dropdown.tsx
+++ b/app/components/Dropdown.tsx
@@ -1,7 +1,7 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import sdk from '@stackblitz/sdk'
 import { stopEventPropagation, useToasts } from '@tldraw/tldraw'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { createReplitProject } from '../lib/uploadToReplit'
 import { createStackBlitzProject, getCodeSandboxUrl } from '../lib/uploadToThirdParty'
 
@@ -16,6 +16,7 @@ export function Dropdown({
 	html: string
 	uploadUrl: string
 }) {
+	const [open, setOpen] = useState(false)
 	const toast = useToasts()
 
 	const copyLink = useCallback(() => {
@@ -46,41 +47,34 @@ export function Dropdown({
 		sdk.openProject(createStackBlitzProject(html), { openFile: 'index.html' })
 	}, [html])
 
-	const openInReplit = useCallback(async () => {
-		const loadingId = toast.addToast({
-			title: 'Creating your Replit project...',
-		})
+	const [isLoadingReplit, setLoadingReplit] = useState(false)
+	const openInReplit = useCallback(
+		async (e: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => {
+			e.preventDefault()
+			if (isLoadingReplit) {
+				return
+			}
 
-		const { error, url } = await createReplitProject(html)
+			setLoadingReplit(true)
+			const { error, url } = await createReplitProject(html)
+			setLoadingReplit(false)
+			if (error) {
+				toast.addToast({ title: 'There was a problem generating your Repl' })
+			} else {
+				window.open(url)
+			}
 
-		toast.removeToast(loadingId)
-		if (error) {
-			toast.addToast({
-				title: 'There was a problem generating your Repl',
-			})
-		} else {
-			toast.addToast({
-				icon: 'code',
-				title: 'Replit project created',
-				actions: [
-					{
-						type: 'primary',
-						label: 'Open project',
-						onClick: () => {
-							window.open(url)
-						},
-					},
-				],
-			})
-		}
-	}, [html, toast])
+			setOpen(false)
+		},
+		[html, isLoadingReplit, toast]
+	)
 
 	// const openInCodePen = useCallback(async () => {
 	// 	window.open(getCodePenUrl(html))
 	// }, [html])
 
 	return (
-		<DropdownMenu.Root>
+		<DropdownMenu.Root open={open} onOpenChange={setOpen}>
 			<DropdownMenu.Trigger>{children}</DropdownMenu.Trigger>
 			<DropdownMenu.Portal>
 				<DropdownMenu.Content side="right" sideOffset={10} align="start">
@@ -101,7 +95,9 @@ export function Dropdown({
 						<Item action={() => window.open(uploadUrl)}>Open in new tab</Item>
 						<Item action={openInCodeSandbox}>Open in CodeSandbox</Item>
 						<Item action={openInStackBlitz}>Open in StackBlitz</Item>
-						<Item action={openInReplit}>Open in Replit</Item>
+						<Item action={openInReplit} rightContent={isLoadingReplit ? <Spinner /> : undefined}>
+							Open in Replit
+						</Item>
 						{/* <Item action={openInCodePen}>Open in CodePen</Item> */}
 					</div>
 				</DropdownMenu.Content>
@@ -110,20 +106,54 @@ export function Dropdown({
 	)
 }
 
-function Item({ action, children }: { action: () => void; children: React.ReactNode }) {
+function Item({
+	action,
+	children,
+	rightContent,
+}: {
+	action: (e: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => void
+	children: React.ReactNode
+	rightContent?: React.ReactNode
+}) {
 	return (
 		<DropdownMenu.Item asChild>
 			<button
 				onPointerDown={stopEventPropagation}
 				onClick={action}
 				onTouchEnd={action}
-				className=" hover:bg-gray-100 outline-none h-9 px-3 text-left w-full rounded-md box-border"
+				className=" hover:bg-gray-100 outline-none h-9 px-3 text-left w-full rounded-md box-border flex justify-between align-middle items-center gap-x-4"
 				style={{
 					textShadow: '1px 1px #fff',
 				}}
 			>
 				{children}
+				{rightContent}
 			</button>
 		</DropdownMenu.Item>
+	)
+}
+
+function Spinner() {
+	return (
+		<svg
+			className="animate-spin h-5 w-5"
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+		>
+			<circle
+				className="opacity-25"
+				cx="12"
+				cy="12"
+				r="10"
+				stroke="currentColor"
+				stroke-width="3"
+			></circle>
+			<path
+				className="opacity-50"
+				fill="currentColor"
+				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+			></path>
+		</svg>
 	)
 }

--- a/app/components/Dropdown.tsx
+++ b/app/components/Dropdown.tsx
@@ -1,12 +1,9 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import sdk from '@stackblitz/sdk'
 import { stopEventPropagation, useToasts } from '@tldraw/tldraw'
 import { useCallback } from 'react'
-import {
-	createStackBlitzProject,
-	getCodePenUrl,
-	getCodeSandboxUrl,
-} from '../lib/uploadToThirdParty'
-import sdk from '@stackblitz/sdk'
+import { createReplitProject } from '../lib/uploadToReplit'
+import { createStackBlitzProject, getCodeSandboxUrl } from '../lib/uploadToThirdParty'
 
 export function Dropdown({
 	boxShadow,
@@ -49,6 +46,35 @@ export function Dropdown({
 		sdk.openProject(createStackBlitzProject(html), { openFile: 'index.html' })
 	}, [html])
 
+	const openInReplit = useCallback(async () => {
+		const loadingId = toast.addToast({
+			title: 'Creating your Replit project...',
+		})
+
+		const { error, url } = await createReplitProject(html)
+
+		toast.removeToast(loadingId)
+		if (error) {
+			toast.addToast({
+				title: 'There was a problem generating your Repl',
+			})
+		} else {
+			toast.addToast({
+				icon: 'code',
+				title: 'Replit project created',
+				actions: [
+					{
+						type: 'primary',
+						label: 'Open project',
+						onClick: () => {
+							window.open(url)
+						},
+					},
+				],
+			})
+		}
+	}, [html, toast])
+
 	// const openInCodePen = useCallback(async () => {
 	// 	window.open(getCodePenUrl(html))
 	// }, [html])
@@ -75,6 +101,7 @@ export function Dropdown({
 						<Item action={() => window.open(uploadUrl)}>Open in new tab</Item>
 						<Item action={openInCodeSandbox}>Open in CodeSandbox</Item>
 						<Item action={openInStackBlitz}>Open in StackBlitz</Item>
+						<Item action={openInReplit}>Open in Replit</Item>
 						{/* <Item action={openInCodePen}>Open in CodePen</Item> */}
 					</div>
 				</DropdownMenu.Content>

--- a/app/lib/uploadToReplit.ts
+++ b/app/lib/uploadToReplit.ts
@@ -1,0 +1,21 @@
+'use server'
+
+export async function createReplitProject(
+	html: string
+): Promise<{ error: true; url: undefined } | { error: undefined; url: string }> {
+	const response = await fetch('https://replit.com/external/v1/claims', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			title: 'My Tldraw Repl',
+			files: [{ path: 'index.html', content: html }],
+			secret: process.env.REPLIT_CLAIMS_KEY,
+		}),
+	}).then((r) => r.json())
+
+	if (response.success) {
+		return { error: undefined, url: response.link }
+	}
+
+	return { error: true, url: undefined }
+}


### PR DESCRIPTION
Demoing a potential "Open in Replit" option ahead of our meeting on Thursday :)

Our current API is a bit different than the other ones in that it requires a POST to receive a URL to visit. So I chose to use toasts to communicate the updates to the user. We could potentially also auto-open the URL when we receive it.

You will need a secret key from us to store in a `REPLIT_CLAIMS_KEY` environment variable.

This video mocks a few things:
* Mocks out the "tldraw link" stuff since I didn't get postgres working (this is why the preview looks bad)
* Mocks the openai response to just be a basic `<html>lorem ipsum...</html>`

https://github.com/tldraw/make-real/assets/16962017/61da5aba-1fe9-404e-8f24-54dc5a652a40


