### PR TITLE
Add "Open in LiveCodes"

### DIFF
--- a/app/components/Dropdown.tsx
+++ b/app/components/Dropdown.tsx
@@ -6,6 +6,7 @@ import {
 	createReplitProject,
 	createStackBlitzProject,
 	getCodeSandboxUrl,
+	getLiveCodesUrl,
 } from '../lib/uploadToThirdParty'
 
 export function Dropdown({
@@ -73,6 +74,15 @@ export function Dropdown({
 		}
 	}, [html, toast])
 
+	const openInLiveCodes = useCallback(() => {
+		try {
+			const project = getLiveCodesUrl(html)
+			window.open(project)
+		} catch {
+			toast.addToast({ title: 'There was a problem opening in LiveCodes.' })
+		}
+	}, [html, toast])
+
 	// const openInCodePen = useCallback(async () => {
 	// 	window.open(getCodePenUrl(html))
 	// }, [html])
@@ -100,6 +110,7 @@ export function Dropdown({
 						<Item action={openInCodeSandbox}>Open in CodeSandbox</Item>
 						<Item action={openInStackBlitz}>Open in StackBlitz</Item>
 						<Item action={openInReplit}>Open in Replit</Item>
+						<Item action={openInLiveCodes}>Open in LiveCodes</Item>
 						{/* <Item action={openInCodePen}>Open in CodePen</Item> */}
 					</div>
 				</DropdownMenu.Content>

--- a/app/lib/uploadToThirdParty.ts
+++ b/app/lib/uploadToThirdParty.ts
@@ -57,6 +57,19 @@ export function getCodeSandboxUrl(html: string) {
 	return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${project}`
 }
 
+export function getLiveCodesUrl(html: string) {
+	const config = {
+		title: 'Make real from tldraw',
+		description: 'Your AI generated example made at https://makereal.tldraw.com/',
+		markup: {
+			language: 'html',
+			content: html,
+		},
+	}
+	const compressed = LZString.compressToEncodedURIComponent(JSON.stringify(config))
+	return `https://livecodes.io/?x=code/${compressed}`
+}
+
 // The following two functions are from
 // https://github.com/codesandbox/codesandbox-importers/blob/master/packages/import-utils/src/api/define.17:41:36
 // They are licensed under GPLv3 and from my understanding usning them here is fine since we are using GNU Affero General Public License v3.0


### PR DESCRIPTION
This PR adds "Open in LiveCodes" option.

[LiveCodes](https://livecodes.io) is a [feature-rich](https://livecodes.io/docs/features/), [open-source](https://github.com/live-codes/livecodes), [client-side](https://livecodes.io/docs/why/#client-side), code playground that supports [80+ languages and frameworks](https://livecodes.io/docs/why/#language-support).  

LiveCodes playgrounds can be [embedded](https://livecodes.io/docs/features/embeds) in any webpage, using a powerful, yet easy-to-use, [SDK](https://livecodes.io/docs/sdk).

App: https://livecodes.io
Docs: https://livecodes.io/docs
What is different about LiveCodes: https://livecodes.io/docs/why
GitHub repo: https://github.com/live-codes/livecodes