### PR TITLE
Add slides to `/demo` route

### DIFF
--- a/app/Slides/SlideShapeTool.tsx
+++ b/app/Slides/SlideShapeTool.tsx
@@ -1,0 +1,7 @@
+import { BaseBoxShapeTool } from 'tldraw'
+
+export class SlideShapeTool extends BaseBoxShapeTool {
+	static override id = 'slide'
+	static override initial = 'idle'
+	override shapeType = 'slide'
+}

--- a/app/Slides/SlideShapeUtil.tsx
+++ b/app/Slides/SlideShapeUtil.tsx
@@ -1,0 +1,127 @@
+import { useCallback } from 'react'
+import {
+	Geometry2d,
+	Rectangle2d,
+	SVGContainer,
+	ShapeProps,
+	ShapeUtil,
+	T,
+	TLBaseShape,
+	TLOnResizeHandler,
+	resizeBox,
+	useValue,
+} from 'tldraw'
+import { getPerfectDashProps } from '../lib/getPerfectDashProps'
+import { moveToSlide, useSlides } from './useSlides'
+
+export type SlideShape = TLBaseShape<
+	'slide',
+	{
+		w: number
+		h: number
+	}
+>
+
+export class SlideShapeUtil extends ShapeUtil<SlideShape> {
+	static override type = 'slide' as const
+	static override props: ShapeProps<SlideShape> = {
+		w: T.number,
+		h: T.number,
+	}
+
+	override canBind = () => false
+	override hideRotateHandle = () => true
+
+	getDefaultProps(): SlideShape['props'] {
+		return {
+			w: 720,
+			h: 480,
+		}
+	}
+
+	getGeometry(shape: SlideShape): Geometry2d {
+		return new Rectangle2d({
+			width: shape.props.w,
+			height: shape.props.h,
+			isFilled: false,
+		})
+	}
+
+	override onRotate = (initial: SlideShape) => initial
+	override onResize: TLOnResizeHandler<SlideShape> = (shape, info) => {
+		return resizeBox(shape, info)
+	}
+
+	override onDoubleClick = (shape: SlideShape) => {
+		moveToSlide(this.editor, shape)
+		this.editor.selectNone()
+	}
+
+	override onDoubleClickEdge = (shape: SlideShape) => {
+		moveToSlide(this.editor, shape)
+		this.editor.selectNone()
+	}
+
+	component(shape: SlideShape) {
+		const bounds = this.editor.getShapeGeometry(shape).bounds
+
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const zoomLevel = useValue('zoom level', () => this.editor.getZoomLevel(), [this.editor])
+
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const slides = useSlides()
+		const index = slides.findIndex((s) => s.id === shape.id)
+
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const handleLabelPointerDown = useCallback(() => this.editor.select(shape.id), [shape.id])
+
+		if (!bounds) return null
+
+		return (
+			<>
+				<div onPointerDown={handleLabelPointerDown} className="slide-shape-label">
+					{`Slide ${index + 1}`}
+				</div>
+				<SVGContainer>
+					<g
+						style={{
+							stroke: 'var(--color-text)',
+							strokeWidth: 'calc(1px * var(--tl-scale))',
+							opacity: 0.25,
+						}}
+						pointerEvents="none"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						{bounds.sides.map((side, i) => {
+							const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
+								side[0].dist(side[1]),
+								1 / zoomLevel,
+								{
+									style: 'dashed',
+									lengthRatio: 6,
+								}
+							)
+
+							return (
+								<line
+									key={i}
+									x1={side[0].x}
+									y1={side[0].y}
+									x2={side[1].x}
+									y2={side[1].y}
+									strokeDasharray={strokeDasharray}
+									strokeDashoffset={strokeDashoffset}
+								/>
+							)
+						})}
+					</g>
+				</SVGContainer>
+			</>
+		)
+	}
+
+	indicator(shape: SlideShape) {
+		return <rect width={shape.props.w} height={shape.props.h} />
+	}
+}

--- a/app/Slides/SlidesPanel.tsx
+++ b/app/Slides/SlidesPanel.tsx
@@ -1,0 +1,32 @@
+import { TldrawUiButton, stopEventPropagation, track, useEditor, useValue } from 'tldraw'
+import { moveToSlide, useCurrentSlide, useSlides } from './useSlides'
+
+export const SlidesPanel = track(() => {
+	const editor = useEditor()
+	const slides = useSlides()
+	const currentSlide = useCurrentSlide()
+	const selectedShapes = useValue('selected shapes', () => editor.getSelectedShapes(), [editor])
+
+	if (slides.length === 0) return null
+	return (
+		<div className="slides-panel scroll-light" onPointerDown={(e) => stopEventPropagation(e)}>
+			{slides.map((slide, i) => {
+				const isSelected = selectedShapes.includes(slide)
+				return (
+					<TldrawUiButton
+						key={'slides-panel-button:' + slide.id}
+						type="normal"
+						className="slides-panel-button"
+						onClick={() => moveToSlide(editor, slide)}
+						style={{
+							background: currentSlide?.id === slide.id ? 'var(--color-background)' : 'transparent',
+							outline: isSelected ? 'var(--color-selection-stroke) solid 1.5px' : 'none',
+						}}
+					>
+						{`Slide ${i + 1}`}
+					</TldrawUiButton>
+				)
+			})}
+		</div>
+	)
+})

--- a/app/Slides/slides.css
+++ b/app/Slides/slides.css
@@ -1,0 +1,32 @@
+.slides-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	max-height: calc(100% - 110px);
+	margin: 50px 0px;
+	padding: 4px;
+	background-color: var(--color-low);
+	pointer-events: all;
+	border-top-right-radius: var(--radius-4);
+	border-bottom-right-radius: var(--radius-4);
+	overflow: auto;
+	border-right: 2px solid var(--color-background);
+	border-bottom: 2px solid var(--color-background);
+	border-top: 2px solid var(--color-background);
+}
+
+.slides-panel-button {
+	border-radius: var(--radius-4);
+	outline-offset: -1px;
+}
+
+.slide-shape-label {
+	pointer-events: all;
+	position: absolute;
+	background: var(--color-low);
+	padding: calc(12px * var(--tl-scale));
+	border-bottom-right-radius: calc(var(--radius-4) * var(--tl-scale));
+	font-size: calc(12px * var(--tl-scale));
+	color: var(--color-text);
+	white-space: nowrap;
+}

--- a/app/Slides/useSlides.tsx
+++ b/app/Slides/useSlides.tsx
@@ -1,0 +1,28 @@
+import { EASINGS, Editor, atom, useEditor, useValue } from 'tldraw'
+import { SlideShape } from './SlideShapeUtil'
+
+export const $currentSlide = atom<SlideShape | null>('current slide', null)
+
+export function moveToSlide(editor: Editor, slide: SlideShape) {
+	const bounds = editor.getShapePageBounds(slide.id)
+	if (!bounds) return
+	$currentSlide.set(slide)
+	editor.selectNone()
+	editor.zoomToBounds(bounds, { duration: 500, easing: EASINGS.easeInOutCubic, inset: 0 })
+}
+
+export function useSlides() {
+	const editor = useEditor()
+	return useValue<SlideShape[]>('slide shapes', () => getSlides(editor), [editor])
+}
+
+export function useCurrentSlide() {
+	return useValue($currentSlide)
+}
+
+export function getSlides(editor: Editor) {
+	return editor
+		.getSortedChildIdsForParent(editor.getCurrentPageId())
+		.map((id) => editor.getShape(id))
+		.filter((s) => s?.type === 'slide') as SlideShape[]
+}

--- a/app/lib/getPerfectDashProps.ts
+++ b/app/lib/getPerfectDashProps.ts
@@ -1,0 +1,96 @@
+import { TLDefaultDashStyle } from 'tldraw'
+
+export function getPerfectDashProps(
+	totalLength: number,
+	strokeWidth: number,
+	opts = {} as Partial<{
+		style: TLDefaultDashStyle
+		snap: number
+		end: 'skip' | 'outset' | 'none'
+		start: 'skip' | 'outset' | 'none'
+		lengthRatio: number
+		closed: boolean
+	}>
+): {
+	strokeDasharray: string
+	strokeDashoffset: string
+} {
+	const {
+		closed = false,
+		snap = 1,
+		start = 'outset',
+		end = 'outset',
+		lengthRatio = 2,
+		style = 'dashed',
+	} = opts
+
+	let dashLength = 0
+	let dashCount = 0
+	let ratio = 1
+	let gapLength = 0
+	let strokeDashoffset = 0
+
+	switch (style) {
+		case 'dashed': {
+			ratio = 1
+			dashLength = Math.min(strokeWidth * lengthRatio, totalLength / 4)
+			break
+		}
+		case 'dotted': {
+			ratio = 100
+			dashLength = strokeWidth / ratio
+			break
+		}
+		default: {
+			return {
+				strokeDasharray: 'none',
+				strokeDashoffset: 'none',
+			}
+		}
+	}
+
+	if (!closed) {
+		if (start === 'outset') {
+			totalLength += dashLength / 2
+			strokeDashoffset += dashLength / 2
+		} else if (start === 'skip') {
+			totalLength -= dashLength
+			strokeDashoffset -= dashLength
+		}
+
+		if (end === 'outset') {
+			totalLength += dashLength / 2
+		} else if (end === 'skip') {
+			totalLength -= dashLength
+		}
+	}
+
+	dashCount = Math.floor(totalLength / dashLength / (2 * ratio))
+	dashCount -= dashCount % snap
+
+	if (dashCount < 3 && style === 'dashed') {
+		if (totalLength / strokeWidth < 5) {
+			dashLength = totalLength
+			dashCount = 1
+			gapLength = 0
+		} else {
+			dashLength = totalLength * 0.333
+			gapLength = totalLength * 0.333
+		}
+	} else {
+		dashCount = Math.max(dashCount, 3)
+		dashLength = totalLength / dashCount / (2 * ratio)
+
+		if (closed) {
+			strokeDashoffset = dashLength / 2
+			gapLength = (totalLength - dashCount * dashLength) / dashCount
+		} else {
+			gapLength = (totalLength - dashCount * dashLength) / Math.max(1, dashCount - 1)
+		}
+	}
+
+	return {
+		strokeDasharray: [dashLength, gapLength].join(' '),
+		strokeDashoffset: strokeDashoffset.toString(),
+	}
+}

--- a/app/makereal.tldraw.com/demo/page.tsx
+++ b/app/makereal.tldraw.com/demo/page.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable @next/next/no-img-element */
+/* eslint-disable react-hooks/rules-of-hooks */
+'use client'
+
+import dynamic from 'next/dynamic'
+import 'tldraw/tldraw.css'
+import { PreviewShapeUtil } from '../../PreviewShape/PreviewShape'
+import '../../Slides/slides.css'
+import { APIKeyInput } from '../../components/APIKeyInput'
+import { ExportButton } from '../../components/ExportButton'
+
+import { TLUiOverrides, computed } from 'tldraw'
+import { SlideShapeTool } from '../../Slides/SlideShapeTool'
+import { SlideShapeUtil } from '../../Slides/SlideShapeUtil'
+import { SlidesPanel } from '../../Slides/SlidesPanel'
+import { $currentSlide, getSlides, moveToSlide } from '../../Slides/useSlides'
+import { LinkArea } from '../../components/LinkArea'
+
+const Tldraw = dynamic(async () => (await import('tldraw')).Tldraw, {
+	ssr: false,
+})
+
+const overrides: TLUiOverrides = {
+	actions(editor, actions) {
+		const $slides = computed('slides', () => getSlides(editor))
+		return {
+			...actions,
+			'next-slide': {
+				id: 'next-slide',
+				label: 'Next slide',
+				kbd: 'right',
+				onSelect() {
+					const slides = $slides.get()
+					const currentSlide = $currentSlide.get()
+					const index = slides.findIndex((s) => s.id === currentSlide?.id)
+					const nextSlide = slides[index + 1] ?? currentSlide ?? slides[0]
+					if (nextSlide) {
+						editor.stopCameraAnimation()
+						moveToSlide(editor, nextSlide)
+					}
+				},
+			},
+			'previous-slide': {
+				id: 'previous-slide',
+				label: 'Previous slide',
+				kbd: 'left',
+				onSelect() {
+					const slides = $slides.get()
+					const currentSlide = $currentSlide.get()
+					const index = slides.findIndex((s) => s.id === currentSlide?.id)
+					const previousSlide = slides[index - 1] ?? currentSlide ?? slides[slides.length - 1]
+					if (previousSlide) {
+						editor.stopCameraAnimation()
+						moveToSlide(editor, previousSlide)
+					}
+				},
+			},
+		}
+	},
+	tools(editor, tools) {
+		tools.slide = {
+			id: 'slide',
+			icon: 'group',
+			label: 'Slide',
+			kbd: 's',
+			onSelect: () => editor.setCurrentTool('slide'),
+		}
+		return tools
+	},
+}
+
+export default function Home() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="tldraw-demo"
+				shapeUtils={[PreviewShapeUtil, SlideShapeUtil]}
+				tools={[SlideShapeTool]}
+				overrides={overrides}
+				components={{
+					SharePanel: ExportButton,
+					HelperButtons: SlidesPanel,
+					Minimap: null,
+				}}
+				onMount={(editor) => {
+					window['editor'] = editor
+				}}
+			>
+				<APIKeyInput />
+				<LinkArea />
+			</Tldraw>
+		</div>
+	)
+}

--- a/app/makereal.tldraw.com/page.tsx
+++ b/app/makereal.tldraw.com/page.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 'use client'
 
-import 'tldraw/tldraw.css'
 import dynamic from 'next/dynamic'
+import 'tldraw/tldraw.css'
 import { PreviewShapeUtil } from '../PreviewShape/PreviewShape'
 import { APIKeyInput } from '../components/APIKeyInput'
 import { ExportButton } from '../components/ExportButton'


### PR DESCRIPTION
This PR adds a new route, `/demo` that has slides enabled.