### PR TITLE
Add missing toasts

### DIFF
--- a/app/hooks/useMakeReal.ts
+++ b/app/hooks/useMakeReal.ts
@@ -8,7 +8,7 @@ import { blobToBase64 } from '../lib/blobToBase64'
 import { getMessages } from '../lib/getMessages'
 import { getTextFromSelectedShapes } from '../lib/getTextFromSelectedShapes'
 import { htmlify } from '../lib/htmlify'
-import { PROVIDERS, makeRealSettings } from '../lib/settings'
+import { makeRealSettings, PROVIDERS } from '../lib/settings'
 import { uploadLink } from '../lib/uploadLink'
 
 export function useMakeReal() {
@@ -354,6 +354,11 @@ export function useMakeReal() {
 
 						console.log(`Response: ${result.text}`)
 					} catch (e) {
+						addToast({
+							icon: 'info-circle',
+							title: 'Something went wrong',
+							description: (e as Error).message.slice(0, 100),
+						})
 						console.error(e.message)
 						// If anything went wrong, delete the shape.
 						editor.deleteShape(newShapeId)


### PR DESCRIPTION
When a model fails to provide a response, it fails silently. Let's add a toast to make it clear that it's not our fault.